### PR TITLE
MLOPS-308: Hide user token from tests.

### DIFF
--- a/tests/testthat/testthat.R
+++ b/tests/testthat/testthat.R
@@ -1,10 +1,13 @@
 library(testthat)
+library(yaml)
 source("/Users/pierre/PycharmProjects/romigami/R/romigami.R")
 
 test_that("integration is correct", {
   initialize_environment()
   mgf_path <- paste0(dirname(getwd()), "/romigami/tests/assets/GNPS-COLLECTIONS-MISC.mgf")
-  token <- Sys.getenv("ROMIGAMI_TOKEN")
+  config_path <- file.path("~/.config/omigami/config.yaml")
+  config <- yaml::yaml.load_file(input = config_path)
+  token <- config$login$dev$token
   results <- match_spectra_from_path(token,
                                      mgf_path,
                                      10,

--- a/tests/testthat/testthat.R
+++ b/tests/testthat/testthat.R
@@ -10,6 +10,7 @@ test_that("integration is correct", {
                                      10,
                                      list("Smiles", "Compound_name"),
                                      "positive"
+  )
   expect_equal(length(results), 46)
 })
 

--- a/tests/testthat/testthat.R
+++ b/tests/testthat/testthat.R
@@ -1,6 +1,6 @@
 library(testthat)
 library(yaml)
-source("/Users/pierre/PycharmProjects/romigami/R/romigami.R")
+source("R/romigami.R")
 
 test_that("integration is correct", {
   initialize_environment()

--- a/tests/testthat/testthat.R
+++ b/tests/testthat/testthat.R
@@ -4,7 +4,8 @@ library(romigami)
 test_that("integration is correct", {
   initialize_environment()
   mgf_path <- paste0(dirname(getwd()), "/romigami/tests/assets/GNPS-COLLECTIONS-MISC.mgf")
-  results <- match_spectra_from_path(token = "8DmWwNrFB8oSQcjHsEabHoNcUy30MZLY",
+  token <- Sys.getenv("ROMIGAMI_TOKEN")
+  results <- match_spectra_from_path(token = token,
                                      mgf_path = mgf_path,
                                      n_best = 10)
   expect_equal(length(results), 46)


### PR DESCRIPTION
Currently the user token (expiring on 23/06) explicitly displayed in tests. Have it as an environment variable instead, like in omigami-core
